### PR TITLE
Adding 80 Hz square wave test signal support

### DIFF
--- a/MMDVMCal.cpp
+++ b/MMDVMCal.cpp
@@ -139,6 +139,10 @@ int CMMDVMCal::run()
 			case 'd':
 				setDSTAR();
 				break;
+			case 'L':
+			case 'l':
+				setLowFrequencyCal();
+				break;
 			case 'S':
 			case 's':
 				setRSSI();
@@ -188,6 +192,7 @@ void CMMDVMCal::displayHelp()
 	::fprintf(stdout, "    T        Increase transmit level" EOL);
 	::fprintf(stdout, "    t        Decrease transmit level" EOL);
 	::fprintf(stdout, "    D        DMR Deviation Mode (Adjust for 2.75Khz Deviation)" EOL);
+	::fprintf(stdout, "    L/l      DMR Low Frequency Mode (80 Hz square wave)" EOL);
 	::fprintf(stdout, "    d        D-Star Mode" EOL);
 	::fprintf(stdout, "    S/s      RSSI Mode" EOL);
 	::fprintf(stdout, "    V/v      Display version of MMDVMCal" EOL);
@@ -318,6 +323,15 @@ bool CMMDVMCal::setDMRDeviation()
 	m_mode=98;
 
 	::fprintf(stdout, "DMR Deviation Mode (Set to 2.75Khz Deviation)" EOL);
+
+	return writeConfig();
+}
+
+bool CMMDVMCal::setLowFrequencyCal()
+{
+	m_mode=95;
+
+	::fprintf(stdout, "DMR Low Frequency Mode (80 Hz square wave)" EOL);
 
 	return writeConfig();
 }

--- a/MMDVMCal.h
+++ b/MMDVMCal.h
@@ -52,6 +52,7 @@ private:
 	bool setRXInvert();
 	bool setPTTInvert();
 	bool setDMRDeviation();
+	bool setLowFrequencyCal();
 	bool setDSTAR();
 	bool setRSSI();
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ the following commands:
 <tr><td>T</td><td>Increase transmit level</td></tr>
 <tr><td>t</td><td>Decrease transmit level</td></tr>
 <tr><td>D</td><td>Set DMR Deviation Mode. Generates a 1.2Khz Sinewave. Set radio for 2.75 Khz Deviation</td></tr>
+<tr><td>L/l</td><td>DMR Low Frequency Mode (80 Hz square wave)</td></tr>
 <tr><td>d</td><td>D-Star mode</td></tr>
 <tr><td>S/s</td><td>RSSI Mode</td></tr>
 <tr><td>V/v</td><td>Display version of MMDVMCal</td></tr>


### PR DESCRIPTION
Useful test signal for verifying TX analog radio compatibility with MMDVM or adjusting a two-point FM modulator. 