### PR TITLE
add OpenBSD support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 all:	MMDVMCal
 
-LD  = g++
-CXX = g++
+LD  = c++
+CXX = c++
 
 CXXFLAGS = -O2 -Wall -std=c++0x
 
@@ -31,7 +31,7 @@ NXDNLICH.o:	NXDNLICH.cpp NXDNLICH.h NXDNDefines.h
 
 SerialController.o:	SerialController.cpp SerialController.h
 		$(CXX) $(CXXFLAGS) -c SerialController.cpp
-	
+
 SerialPort.o:	SerialPort.cpp SerialPort.h
 		$(CXX) $(CXXFLAGS) -c SerialPort.cpp
 

--- a/SerialController.cpp
+++ b/SerialController.cpp
@@ -290,28 +290,18 @@ bool CSerialController::open()
 			return false;
 		}
 
+		termios.c_iflag &= ~(IGNBRK | BRKINT | IGNPAR | PARMRK | INPCK);
+		termios.c_iflag &= ~(ISTRIP | INLCR | IGNCR | ICRNL);
+		termios.c_iflag &= ~(IXON | IXOFF | IXANY);
+		termios.c_oflag &= ~(OPOST);
+		termios.c_cflag &= ~(CSIZE | CSTOPB | PARENB | CRTSCTS);
+		termios.c_cflag |=  (CS8 | CLOCAL | CREAD);
+		termios.c_lflag &= ~(ISIG | ICANON | IEXTEN);
+		termios.c_lflag &= ~(ECHO | ECHOE | ECHOK | ECHONL);
 #if defined(__APPLE__)
-		termios.c_cflag |= (CLOCAL | CREAD);    /* ignore modem controls */
-		termios.c_cflag &= ~CSIZE;
-		termios.c_cflag |= CS8;         /* 8-bit characters */
-		termios.c_cflag &= ~PARENB;     /* no parity bit */
-		termios.c_cflag &= ~CSTOPB;     /* only need 1 stop bit */
-		termios.c_cflag &= ~CRTSCTS;    /* no hardware flowcontrol */
-
-		/* setup for non-canonical mode */
-		termios.c_iflag &= ~(IGNBRK | BRKINT | PARMRK | ISTRIP | INLCR | IGNCR | ICRNL | IXON);
-		termios.c_lflag &= ~(ECHO | ECHONL | ICANON | ISIG | IEXTEN);
-		termios.c_oflag &= ~OPOST;
-
-		/* fetch bytes as they become available */
 		termios.c_cc[VMIN] = 1;
 		termios.c_cc[VTIME] = 1;
 #else
-		termios.c_lflag    &= ~(ECHO | ECHOE | ICANON | IEXTEN | ISIG);
-		termios.c_iflag    &= ~(BRKINT | ICRNL | INPCK | ISTRIP | IXON | IXOFF | IXANY);
-		termios.c_cflag    &= ~(CSIZE | CSTOPB | PARENB | CRTSCTS);
-		termios.c_cflag    |= CS8;
-		termios.c_oflag    &= ~(OPOST);
 		termios.c_cc[VMIN]  = 0;
 		termios.c_cc[VTIME] = 10;
 #endif

--- a/SerialController.cpp
+++ b/SerialController.cpp
@@ -34,7 +34,7 @@
 #include <fcntl.h>
 #include <unistd.h>
 #include <termios.h>
-#if !defined(__APPLE__)
+#if defined(__linux__)
 #include <linux/i2c-dev.h>
 #endif
 #endif
@@ -247,7 +247,7 @@ bool CSerialController::open()
 	assert(m_fd == -1);
 
 	if (m_device == "/dev/i2c-1") {
-#if !defined(__APPLE__)
+#if defined(__linux__)
 		m_fd = ::open(m_device.c_str(), O_RDWR);
 		if (m_fd < 0) {
 			::fprintf(stderr, "Cannot open device - %s", m_device.c_str());
@@ -412,7 +412,7 @@ int CSerialController::read(unsigned char* buffer, unsigned int length)
 
 	while (offset < length) {
 		if (m_device == "/dev/i2c-1"){
-#if !defined(__APPLE__)
+#if defined(__linux__)
 			ssize_t c = ::read(m_fd, buffer + offset, 1U);
 			if (c < 0) {
 				if (errno != EAGAIN) {
@@ -494,7 +494,7 @@ int CSerialController::write(const unsigned char* buffer, unsigned int length)
 	while (ptr < length) {
 		ssize_t n = 0U;
 		if (m_device == "/dev/i2c-1"){
-#if !defined(__APPLE__)
+#if defined(__linux__)
 			n = ::write(m_fd, buffer + ptr, 1U);
 #endif
 		} else {


### PR DESCRIPTION
To work MMDVMCal on OpenBSD/armv7 + BananaPi BPI-P2, I needed these changes.
Especially adding CLOCAL flag for termios is mandatory (this change is required for other codes like MMDVMHost).
